### PR TITLE
Message sent in push notification payload for chat push notifications

### DIFF
--- a/src/main/java/com/hedvig/notificationService/service/FirebaseNotificationService.kt
+++ b/src/main/java/com/hedvig/notificationService/service/FirebaseNotificationService.kt
@@ -5,7 +5,7 @@ import java.util.Optional
 
 interface FirebaseNotificationService {
 
-    fun sendNewMessageNotification(memberId: String)
+    fun sendNewMessageNotification(memberId: String, messageText: String?)
 
     fun sendReferredSuccessNotification(
         memberId: String,

--- a/src/main/java/com/hedvig/notificationService/service/FirebaseNotificationServiceImpl.kt
+++ b/src/main/java/com/hedvig/notificationService/service/FirebaseNotificationServiceImpl.kt
@@ -41,10 +41,17 @@ open class FirebaseNotificationServiceImpl(
     private val memberService: MemberServiceClient
 ) : FirebaseNotificationService {
 
-    override fun sendNewMessageNotification(memberId: String) {
+    override fun sendNewMessageNotification(memberId: String, messageText: String?) {
         val firebaseToken = firebaseRepository.findById(memberId)
 
-        val message = createMessage(memberId, firebaseToken, NEW_MESSAGE, DEFAULT_TITLE, NEW_MESSAGE_BODY)
+        val message = createMessage(
+                memberId,
+                firebaseToken,
+                NEW_MESSAGE,
+                DEFAULT_TITLE,
+                NEW_MESSAGE_BODY,
+                customData = messageText?.let { mapOf(DATA_NEW_MESSAGE_BODY to it) }
+        )
 
         sendNotification(NEW_MESSAGE, memberId, message)
     }
@@ -305,6 +312,8 @@ open class FirebaseNotificationServiceImpl(
         const val DATA_MESSAGE_REFERRED_SUCCESS_NAME = "DATA_MESSAGE_REFERRED_SUCCESS_NAME"
         const val DATA_MESSAGE_REFERRED_SUCCESS_INCENTIVE_AMOUNT = "DATA_MESSAGE_REFERRED_SUCCESS_INCENTIVE_AMOUNT"
         const val DATA_MESSAGE_REFERRED_SUCCESS_INCENTIVE_CURRENCY = "DATA_MESSAGE_REFERRED_SUCCESS_INCENTIVE_CURRENCY"
+
+        const val DATA_NEW_MESSAGE_BODY = "DATA_NEW_MESSAGE_BODY"
 
         private val logger = LoggerFactory.getLogger(FirebaseNotificationServiceImpl::class.java)
     }

--- a/src/main/java/com/hedvig/notificationService/web/FirebaseController.kt
+++ b/src/main/java/com/hedvig/notificationService/web/FirebaseController.kt
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.*
 import javax.validation.Valid
 
 @RestController
@@ -61,8 +60,8 @@ class FirebaseController(private val firebaseNotificationService: FirebaseNotifi
 
     @PostMapping("/{memberId}/push/send")
     fun sendPushNotification(
-            @PathVariable memberId: String,
-            @RequestBody request: SendPushNotificationRequest?
+        @PathVariable memberId: String,
+        @RequestBody request: SendPushNotificationRequest?
     ): ResponseEntity<Void> {
         firebaseNotificationService.sendNewMessageNotification(memberId, request?.message)
         return ResponseEntity.noContent().build()

--- a/src/main/java/com/hedvig/notificationService/web/FirebaseController.kt
+++ b/src/main/java/com/hedvig/notificationService/web/FirebaseController.kt
@@ -4,6 +4,7 @@ import com.hedvig.notificationService.dto.ReferralsSuccessSendNotificationReques
 import com.hedvig.notificationService.service.FirebaseNotificationService
 import com.hedvig.notificationService.web.dto.ClaimPaidNotificationRequest
 import com.hedvig.notificationService.web.dto.GenericCommunicationNotificationRequest
+import com.hedvig.notificationService.web.dto.SendPushNotificationRequest
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.util.*
 import javax.validation.Valid
 
 @RestController
@@ -58,8 +60,12 @@ class FirebaseController(private val firebaseNotificationService: FirebaseNotifi
     }
 
     @PostMapping("/{memberId}/push/send")
-    fun sendPushNotification(@PathVariable memberId: String): ResponseEntity<Void> {
-        firebaseNotificationService.sendNewMessageNotification(memberId)
+    fun sendPushNotification(
+            @PathVariable memberId: String,
+            @RequestBody request: Optional<SendPushNotificationRequest>
+    ): ResponseEntity<Void> {
+        val message = request.orElse(null)?.message
+        firebaseNotificationService.sendNewMessageNotification(memberId, message)
         return ResponseEntity.noContent().build()
     }
 

--- a/src/main/java/com/hedvig/notificationService/web/FirebaseController.kt
+++ b/src/main/java/com/hedvig/notificationService/web/FirebaseController.kt
@@ -62,10 +62,9 @@ class FirebaseController(private val firebaseNotificationService: FirebaseNotifi
     @PostMapping("/{memberId}/push/send")
     fun sendPushNotification(
             @PathVariable memberId: String,
-            @RequestBody request: Optional<SendPushNotificationRequest>
+            @RequestBody request: SendPushNotificationRequest?
     ): ResponseEntity<Void> {
-        val message = request.orElse(null)?.message
-        firebaseNotificationService.sendNewMessageNotification(memberId, message)
+        firebaseNotificationService.sendNewMessageNotification(memberId, request?.message)
         return ResponseEntity.noContent().build()
     }
 

--- a/src/main/java/com/hedvig/notificationService/web/dto/SendPushNotificationRequest.kt
+++ b/src/main/java/com/hedvig/notificationService/web/dto/SendPushNotificationRequest.kt
@@ -1,0 +1,5 @@
+package com.hedvig.notificationService.web.dto
+
+data class SendPushNotificationRequest(
+        val message: String
+)

--- a/src/main/java/com/hedvig/notificationService/web/dto/SendPushNotificationRequest.kt
+++ b/src/main/java/com/hedvig/notificationService/web/dto/SendPushNotificationRequest.kt
@@ -1,5 +1,5 @@
 package com.hedvig.notificationService.web.dto
 
 data class SendPushNotificationRequest(
-        val message: String
+    val message: String
 )

--- a/src/test/java/com/hedvig/notificationService/service/FirebaseNotificationServiceImplTest.kt
+++ b/src/test/java/com/hedvig/notificationService/service/FirebaseNotificationServiceImplTest.kt
@@ -83,17 +83,39 @@ internal class FirebaseNotificationServiceImplTest {
     }
 
     @Test
-    fun sendNewMessageNotification() {
+    fun sendNewMessageNotificationWithoutMessage() {
         val title = "title"
         val body = "body"
         every { localizationService.getTranslation("DEFAULT_TITLE", any()) } returns title
         every { localizationService.getTranslation("NEW_MESSAGE_BODY", any()) } returns body
-        classUnderTest.sendNewMessageNotification(MEMBER_ID)
+        classUnderTest.sendNewMessageNotification(MEMBER_ID, null)
 
         deepMatchMessageCommonData(messages[0], mapOf("TYPE" to "NEW_MESSAGE"))
         deepMatchMessageAndroidData(
             messages[0],
             mapOf("TYPE" to "NEW_MESSAGE", "DATA_MESSAGE_TITLE" to title, "DATA_MESSAGE_BODY" to body)
+        )
+        deepMatchMessageIOSData(messages[0], title, body)
+    }
+
+    @Test
+    fun sendNewMessageNotificationWithMessage() {
+        val title = "title"
+        val body = "body"
+        val message = "example message"
+        every { localizationService.getTranslation("DEFAULT_TITLE", any()) } returns title
+        every { localizationService.getTranslation("NEW_MESSAGE_BODY", any()) } returns body
+        classUnderTest.sendNewMessageNotification(MEMBER_ID, message)
+
+        deepMatchMessageCommonData(messages[0], mapOf("TYPE" to "NEW_MESSAGE"))
+        deepMatchMessageAndroidData(
+                messages[0],
+                mapOf(
+                        "TYPE" to "NEW_MESSAGE",
+                        "DATA_MESSAGE_TITLE" to title,
+                        "DATA_MESSAGE_BODY" to body,
+                        FirebaseNotificationServiceImpl.DATA_NEW_MESSAGE_BODY to message
+                )
         )
         deepMatchMessageIOSData(messages[0], title, body)
     }

--- a/src/test/java/com/hedvig/notificationService/service/FirebaseNotificationServiceImplTest.kt
+++ b/src/test/java/com/hedvig/notificationService/service/FirebaseNotificationServiceImplTest.kt
@@ -114,7 +114,7 @@ internal class FirebaseNotificationServiceImplTest {
                         "TYPE" to "NEW_MESSAGE",
                         "DATA_MESSAGE_TITLE" to title,
                         "DATA_MESSAGE_BODY" to body,
-                        FirebaseNotificationServiceImpl.DATA_NEW_MESSAGE_BODY to message
+                        "DATA_NEW_MESSAGE_BODY" to message
                 )
         )
         deepMatchMessageIOSData(messages[0], title, body)


### PR DESCRIPTION
This PR adds the actual chat message into the push notification payload for chat push notifications,
allowing the apps to display this message in the push notification instead of a generic message.

[X] I have tested all code paths locally
[X] All code paths are covered by automatic tests