### PR TITLE
Fix/break out scheduling

### DIFF
--- a/src/main/java/com/hedvig/notificationService/configuration/CustomerIOConfig.kt
+++ b/src/main/java/com/hedvig/notificationService/configuration/CustomerIOConfig.kt
@@ -64,10 +64,8 @@ class CustomerIOConfig() {
         return CustomerioService(
             workspaceSelector,
             repo,
-            CustomerioEventCreatorImpl(),
             clients,
-            contractLoader,
-            configuration.useNorwayHack
+            configuration
         )
     }
 

--- a/src/main/java/com/hedvig/notificationService/configuration/CustomerIOConfig.kt
+++ b/src/main/java/com/hedvig/notificationService/configuration/CustomerIOConfig.kt
@@ -8,7 +8,6 @@ import com.hedvig.notificationService.customerio.ConfigurationProperties
 import com.hedvig.notificationService.customerio.CustomerioService
 import com.hedvig.notificationService.customerio.Workspace
 import com.hedvig.notificationService.customerio.WorkspaceSelector
-import com.hedvig.notificationService.customerio.customerioEvents.CustomerioEventCreatorImpl
 import com.hedvig.notificationService.customerio.hedvigfacades.ContractLoader
 import com.hedvig.notificationService.customerio.hedvigfacades.ContractLoaderImpl
 import com.hedvig.notificationService.customerio.hedvigfacades.FakeContractLoader

--- a/src/main/java/com/hedvig/notificationService/customerio/CustomerioService.kt
+++ b/src/main/java/com/hedvig/notificationService/customerio/CustomerioService.kt
@@ -1,25 +1,21 @@
 package com.hedvig.notificationService.customerio
 
 import com.hedvig.customerio.CustomerioClient
-import com.hedvig.notificationService.customerio.customerioEvents.CustomerioEventCreator
-import com.hedvig.notificationService.customerio.hedvigfacades.ContractLoader
 import com.hedvig.notificationService.customerio.state.CustomerIOStateRepository
 import com.hedvig.notificationService.customerio.state.CustomerioState
 import org.slf4j.LoggerFactory
-import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
 import java.time.Instant
-import java.time.temporal.ChronoUnit
 import javax.transaction.Transactional
 
 const val SIGN_EVENT_WINDOWS_SIZE_MINUTES = 10L
 
-open class CustomerioService(
+@Service
+class CustomerioService(
     private val workspaceSelector: WorkspaceSelector,
     private val stateRepository: CustomerIOStateRepository,
-    private val eventCreator: CustomerioEventCreator,
     private val clients: Map<Workspace, CustomerioClient>,
-    private val contractLoader: ContractLoader,
-    private val useNorwayHack: Boolean
+    private val configuration: ConfigurationProperties
 ) {
 
     private val logger = LoggerFactory.getLogger(CustomerioService::class.java)
@@ -36,7 +32,7 @@ open class CustomerioService(
         }
     }
 
-    open fun updateCustomerAttributes(
+    fun updateCustomerAttributes(
         memberId: String,
         attributes: Map<String, Any?>,
         now: Instant = Instant.now()
@@ -44,7 +40,7 @@ open class CustomerioService(
         val marketForMember = workspaceSelector.getWorkspaceForMember(memberId)
 
         if (marketForMember == Workspace.NORWAY && isSignUpdateFromUnderwriter(attributes)) {
-            if (this.useNorwayHack) {
+            if (configuration.useNorwayHack) {
                 val customerState = stateRepository.findByMemberId(memberId)
                 if (customerState == null) {
                     stateRepository.save(
@@ -67,45 +63,19 @@ open class CustomerioService(
             attributes.containsKey("sign_source")
     }
 
-    open fun deleteCustomer(memberId: String) {
+    fun deleteCustomer(memberId: String) {
         val marketForMember = workspaceSelector.getWorkspaceForMember(memberId)
 
         clients[marketForMember]?.deleteCustomer(memberId)
     }
 
-    open fun sendEvent(memberId: String, body: Map<String, Any?>) {
+    fun sendEvent(memberId: String, body: Map<String, Any?>) {
         val marketForMember = workspaceSelector.getWorkspaceForMember(memberId)
         clients[marketForMember]?.sendEvent(memberId, body)
     }
 
-    // @Scheduled functions cannot have any arguments
-    // so this is a bit of a hack
-    @Scheduled(fixedDelay = 1000 * 30)
     @Transactional
-    open fun scheduledUpdates() {
-        sendUpdates()
-    }
-
-    open fun sendUpdates(timeNow: Instant = Instant.now()) {
-
-        val windowEndTime = timeNow.minus(
-            SIGN_EVENT_WINDOWS_SIZE_MINUTES,
-            ChronoUnit.MINUTES
-        )
-
-        for (customerioState in this.stateRepository.shouldUpdate(windowEndTime)) {
-            logger.info("Running update for ${customerioState.memberId}")
-            try {
-                val contracts = this.contractLoader.getContractInfoForMember(customerioState.memberId)
-                val eventAndState = eventCreator.execute(customerioState, contracts)
-                sendEventAndUpdateState(customerioState, eventAndState.asMap)
-            } catch (ex: RuntimeException) {
-                logger.error("Could not create event from customerio state", ex)
-            }
-        }
-    }
-
-    private fun sendEventAndUpdateState(
+    fun sendEventAndUpdateState(
         customerioState: CustomerioState,
         event: Map<String, Any?>
     ) {
@@ -122,3 +92,4 @@ open class CustomerioService(
         }
     }
 }
+

--- a/src/main/java/com/hedvig/notificationService/customerio/CustomerioService.kt
+++ b/src/main/java/com/hedvig/notificationService/customerio/CustomerioService.kt
@@ -92,4 +92,3 @@ class CustomerioService(
         }
     }
 }
-

--- a/src/main/java/com/hedvig/notificationService/customerio/CustomerioUpdateScheduler.kt
+++ b/src/main/java/com/hedvig/notificationService/customerio/CustomerioUpdateScheduler.kt
@@ -42,5 +42,4 @@ open class CustomerioUpdateScheduler(
             }
         }
     }
-
 }

--- a/src/main/java/com/hedvig/notificationService/customerio/CustomerioUpdateScheduler.kt
+++ b/src/main/java/com/hedvig/notificationService/customerio/CustomerioUpdateScheduler.kt
@@ -1,0 +1,46 @@
+package com.hedvig.notificationService.customerio
+
+import com.hedvig.notificationService.customerio.customerioEvents.CustomerioEventCreator
+import com.hedvig.notificationService.customerio.hedvigfacades.ContractLoader
+import com.hedvig.notificationService.customerio.state.CustomerIOStateRepository
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+open class CustomerioUpdateScheduler(
+    private val eventCreator: CustomerioEventCreator,
+    private val stateRepository: CustomerIOStateRepository,
+    private val contractLoader: ContractLoader,
+    private val customerioService: CustomerioService
+) {
+
+    private val logger =
+        LoggerFactory.getLogger(CustomerioService::class.java)
+
+    // @Scheduled functions cannot have any arguments
+    // so this is a bit of a hack
+    @Scheduled(fixedDelay = 1000 * 30)
+    open fun scheduledUpdates() {
+        sendUpdates()
+    }
+
+    open fun sendUpdates(timeNow: Instant = Instant.now()) {
+        val windowEndTime = timeNow.minus(
+            SIGN_EVENT_WINDOWS_SIZE_MINUTES,
+            ChronoUnit.MINUTES
+        )
+
+        for (customerioState in this.stateRepository.shouldUpdate(windowEndTime)) {
+            logger.info("Running update for ${customerioState.memberId}")
+            try {
+                val contracts = this.contractLoader.getContractInfoForMember(customerioState.memberId)
+                val eventAndState = eventCreator.execute(customerioState, contracts)
+                customerioService.sendEventAndUpdateState(customerioState, eventAndState.asMap)
+            } catch (ex: RuntimeException) {
+                logger.error("Could not create event from customerio state", ex)
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/hedvig/notificationService/customerio/CustomerioUpdateScheduler.kt
+++ b/src/main/java/com/hedvig/notificationService/customerio/CustomerioUpdateScheduler.kt
@@ -16,7 +16,7 @@ open class CustomerioUpdateScheduler(
 ) {
 
     private val logger =
-        LoggerFactory.getLogger(CustomerioService::class.java)
+        LoggerFactory.getLogger(CustomerioUpdateScheduler::class.java)
 
     // @Scheduled functions cannot have any arguments
     // so this is a bit of a hack

--- a/src/test/java/com/hedvig/notificationService/WebIntegrationTestConfig.kt
+++ b/src/test/java/com/hedvig/notificationService/WebIntegrationTestConfig.kt
@@ -7,7 +7,6 @@ import com.hedvig.notificationService.customerio.ConfigurationProperties
 import com.hedvig.notificationService.customerio.CustomerioService
 import com.hedvig.notificationService.customerio.Workspace
 import com.hedvig.notificationService.customerio.WorkspaceSelector
-import com.hedvig.notificationService.customerio.customerioEvents.CustomerioEventCreatorImpl
 import com.hedvig.notificationService.customerio.hedvigfacades.ContractLoader
 import com.hedvig.notificationService.customerio.hedvigfacades.FakeContractLoader
 import com.hedvig.notificationService.customerio.hedvigfacades.MemberServiceImpl

--- a/src/test/java/com/hedvig/notificationService/WebIntegrationTestConfig.kt
+++ b/src/test/java/com/hedvig/notificationService/WebIntegrationTestConfig.kt
@@ -3,6 +3,7 @@ package com.hedvig.notificationService
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.hedvig.customerio.CustomerioClient
 import com.hedvig.customerio.CustomerioMock
+import com.hedvig.notificationService.customerio.ConfigurationProperties
 import com.hedvig.notificationService.customerio.CustomerioService
 import com.hedvig.notificationService.customerio.Workspace
 import com.hedvig.notificationService.customerio.WorkspaceSelector
@@ -44,13 +45,11 @@ class WebIntegrationTestConfig {
         return CustomerioService(
             workspaceSelector,
             InMemoryCustomerIOStateRepository(),
-            CustomerioEventCreatorImpl(),
             mapOf(
                 Workspace.SWEDEN to customerioMock,
                 Workspace.NORWAY to customerioMock
             ),
-            productPricingFacade,
-            true
+            ConfigurationProperties()
         )
     }
 

--- a/src/test/java/com/hedvig/notificationService/customerio/ConfigurableNorwaySignHackTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/ConfigurableNorwaySignHackTest.kt
@@ -32,7 +32,7 @@ class ConfigurableNorwaySignHackTest {
         every { workspaceSelector.getWorkspaceForMember(any()) } returns Workspace.NORWAY
 
         val cut =
-            CustomerioService(workspaceSelector, stateRepository, eventCreator, clients, productPricingFacade, false)
+            CustomerioService(workspaceSelector, stateRepository, clients, ConfigurationProperties().also { it.useNorwayHack = false })
 
         cut.updateCustomerAttributes("someId", makeSignFromUnderwriterMap())
 

--- a/src/test/java/com/hedvig/notificationService/customerio/CustomerioServiceContructionTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/CustomerioServiceContructionTest.kt
@@ -39,7 +39,7 @@ class CustomerioServiceContructionTest {
     @Test
     fun `Throw if no markets are passed in the contructor`() {
         exceptionRule.expect(IllegalArgumentException::class.java)
-        CustomerioService(workspaceSelector, repository, eventCreator, mapOf(), contractLoader, true)
+        CustomerioService(workspaceSelector, repository, mapOf(), ConfigurationProperties())
     }
 
     @Test
@@ -48,10 +48,8 @@ class CustomerioServiceContructionTest {
         CustomerioService(
             workspaceSelector,
             repository,
-            eventCreator,
             mapOf(Workspace.SWEDEN to customerioClient),
-            contractLoader,
-            true
+            ConfigurationProperties()
         )
     }
 
@@ -60,13 +58,11 @@ class CustomerioServiceContructionTest {
         CustomerioService(
             workspaceSelector,
             repository,
-            eventCreator,
             mapOf(
                 Workspace.SWEDEN to customerioClient,
                 Workspace.NORWAY to customerioClient
             ),
-            contractLoader,
-            true
+            ConfigurationProperties()
         )
     }
 }

--- a/src/test/java/com/hedvig/notificationService/customerio/CustomerioServiceDeleteCustomerTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/CustomerioServiceDeleteCustomerTest.kt
@@ -1,7 +1,6 @@
 package com.hedvig.notificationService.customerio
 
 import com.hedvig.customerio.CustomerioClient
-import com.hedvig.notificationService.customerio.customerioEvents.CustomerioEventCreatorImpl
 import com.hedvig.notificationService.customerio.hedvigfacades.ContractLoader
 import com.hedvig.notificationService.customerio.hedvigfacades.MemberServiceImpl
 import com.hedvig.notificationService.customerio.state.InMemoryCustomerIOStateRepository

--- a/src/test/java/com/hedvig/notificationService/customerio/CustomerioServiceDeleteCustomerTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/CustomerioServiceDeleteCustomerTest.kt
@@ -27,13 +27,11 @@ class CustomerioServiceDeleteCustomerTest {
         val cut = CustomerioService(
             WorkspaceSelector(productPricingFacade, memberServiceImpl),
             repository,
-            CustomerioEventCreatorImpl(),
             mapOf(
                 Workspace.SWEDEN to sweClient,
                 Workspace.NORWAY to noClient
             ),
-            productPricingFacade,
-            true
+            ConfigurationProperties()
         )
         cut.deleteCustomer("asdad")
         verify { noClient.deleteCustomer(any()) }
@@ -49,13 +47,11 @@ class CustomerioServiceDeleteCustomerTest {
         val cut = CustomerioService(
             WorkspaceSelector(productPricingFacade, memberServiceImpl),
             repository,
-            CustomerioEventCreatorImpl(),
             mapOf(
                 Workspace.SWEDEN to sweClient,
                 Workspace.NORWAY to noClient
             ),
-            productPricingFacade,
-            true
+            ConfigurationProperties()
         )
         cut.deleteCustomer("asdad")
         verify { sweClient.deleteCustomer(any()) }

--- a/src/test/java/com/hedvig/notificationService/customerio/CustomerioServiceForwardUpdateTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/CustomerioServiceForwardUpdateTest.kt
@@ -2,7 +2,6 @@ package com.hedvig.notificationService.customerio
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.hedvig.customerio.CustomerioMock
-import com.hedvig.notificationService.customerio.customerioEvents.CustomerioEventCreatorImpl
 import com.hedvig.notificationService.customerio.hedvigfacades.ContractLoader
 import com.hedvig.notificationService.customerio.hedvigfacades.MemberServiceImpl
 import com.hedvig.notificationService.customerio.state.InMemoryCustomerIOStateRepository

--- a/src/test/java/com/hedvig/notificationService/customerio/CustomerioServiceForwardUpdateTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/CustomerioServiceForwardUpdateTest.kt
@@ -48,13 +48,11 @@ class CustomerioServiceForwardUpdateTest {
                 memberServiceImpl
             ),
             repository,
-            CustomerioEventCreatorImpl(),
             mapOf(
                 Workspace.SWEDEN to customerIOMockSweden,
                 Workspace.NORWAY to customerIOMockNorway
             ),
-            contractLoader,
-            true
+            ConfigurationProperties().also { it.useNorwayHack = false }
         )
     }
 

--- a/src/test/java/com/hedvig/notificationService/customerio/CustomerioServiceForwardUpdateTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/CustomerioServiceForwardUpdateTest.kt
@@ -51,7 +51,7 @@ class CustomerioServiceForwardUpdateTest {
                 Workspace.SWEDEN to customerIOMockSweden,
                 Workspace.NORWAY to customerIOMockNorway
             ),
-            ConfigurationProperties().also { it.useNorwayHack = false }
+            ConfigurationProperties()
         )
     }
 

--- a/src/test/java/com/hedvig/notificationService/customerio/CustomerioServicePostEventTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/CustomerioServicePostEventTest.kt
@@ -22,13 +22,11 @@ class CustomerioServicePostEventTest {
         val sut = CustomerioService(
             workspaceSelector,
             InMemoryCustomerIOStateRepository(),
-            eventCreator,
             mapOf(
                 Workspace.SWEDEN to sweClient,
                 Workspace.NORWAY to noClient
             ),
-            productPricingFacade,
-            true
+            ConfigurationProperties().also { it.useNorwayHack = false }
         )
 
         every { workspaceSelector.getWorkspaceForMember("8080") } returns Workspace.SWEDEN
@@ -49,14 +47,11 @@ class CustomerioServicePostEventTest {
         val sut = CustomerioService(
             workspaceSelector,
             InMemoryCustomerIOStateRepository(),
-            eventCreator,
-
             mapOf(
                 Workspace.SWEDEN to sweClient,
                 Workspace.NORWAY to noClient
             ),
-            productPricingFacade,
-            true
+            ConfigurationProperties().also { it.useNorwayHack = false }
         )
 
         every { workspaceSelector.getWorkspaceForMember("8080") } returns Workspace.NORWAY

--- a/src/test/java/com/hedvig/notificationService/customerio/CustomerioServicePostEventTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/CustomerioServicePostEventTest.kt
@@ -51,7 +51,7 @@ class CustomerioServicePostEventTest {
                 Workspace.SWEDEN to sweClient,
                 Workspace.NORWAY to noClient
             ),
-            ConfigurationProperties().also { it.useNorwayHack = false }
+            ConfigurationProperties()
         )
 
         every { workspaceSelector.getWorkspaceForMember("8080") } returns Workspace.NORWAY

--- a/src/test/java/com/hedvig/notificationService/customerio/CustomerioServicePostEventTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/CustomerioServicePostEventTest.kt
@@ -26,7 +26,7 @@ class CustomerioServicePostEventTest {
                 Workspace.SWEDEN to sweClient,
                 Workspace.NORWAY to noClient
             ),
-            ConfigurationProperties().also { it.useNorwayHack = false }
+            ConfigurationProperties()
         )
 
         every { workspaceSelector.getWorkspaceForMember("8080") } returns Workspace.SWEDEN

--- a/src/test/java/com/hedvig/notificationService/customerio/NorwaySignHackHandleUpdatesFromUnderwriterTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/NorwaySignHackHandleUpdatesFromUnderwriterTest.kt
@@ -53,7 +53,7 @@ class NorwaySignHackHandleUpdatesFromUnderwriterTest {
                 Workspace.SWEDEN to seCustomerioClient,
                 Workspace.NORWAY to noCustomerIoClient
             ),
-            ConfigurationProperties().also { it.useNorwayHack = false }
+            ConfigurationProperties()
         )
     }
 

--- a/src/test/java/com/hedvig/notificationService/customerio/NorwaySignHackHandleUpdatesFromUnderwriterTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/NorwaySignHackHandleUpdatesFromUnderwriterTest.kt
@@ -49,13 +49,11 @@ class NorwaySignHackHandleUpdatesFromUnderwriterTest {
         sut = CustomerioService(
             workspaceSelector,
             repository,
-            eventCreator,
             mapOf(
                 Workspace.SWEDEN to seCustomerioClient,
                 Workspace.NORWAY to noCustomerIoClient
             ),
-            contractLoader,
-            true
+            ConfigurationProperties().also { it.useNorwayHack = false }
         )
     }
 

--- a/src/test/java/com/hedvig/notificationService/customerio/NorwaySignHackUpdateCustomerIOTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/NorwaySignHackUpdateCustomerIOTest.kt
@@ -65,7 +65,6 @@ class NorwaySignHackUpdateCustomerIOTest {
         scheduler = CustomerioUpdateScheduler(
             eventCreator, repository, contractLoader, customerioService
         )
-
     }
 
     @Test


### PR DESCRIPTION
This should fix this [issue](https://sentry.io/organizations/hedvig/issues/1783876229/?environment=production&project=1265998&query=&sort=date&statsPeriod=14d). But I'm a bit unsure if we want the behavior if one fail it should still keep going with the next one. But that's my guess form the catch on line 40 in the new `CustomerioUpdateScheduler` class