### PR TITLE
Do not send quote created event for members that have singed and those with red flags

### DIFF
--- a/src/main/java/com/hedvig/notificationService/customerio/hedvigfacades/MemberServiceImpl.kt
+++ b/src/main/java/com/hedvig/notificationService/customerio/hedvigfacades/MemberServiceImpl.kt
@@ -1,7 +1,8 @@
 package com.hedvig.notificationService.customerio.hedvigfacades
 
 import com.hedvig.notificationService.serviceIntegration.memberService.MemberServiceClient
-import com.hedvig.notificationService.serviceIntegration.memberService.dto.HasPersonSignedBeforeRequest
+import com.hedvig.notificationService.serviceIntegration.memberService.dto.Flag
+import com.hedvig.notificationService.serviceIntegration.memberService.dto.HasSignedBeforeRequest
 import java.util.Locale
 
 class MemberServiceImpl(private val memberServiceClient: MemberServiceClient) {
@@ -9,7 +10,22 @@ class MemberServiceImpl(private val memberServiceClient: MemberServiceClient) {
         return Locale.forLanguageTag(memberServiceClient.pickedLocale(memberId).body.pickedLocale.replace('_', '-'))
     }
 
-    fun hasPersonSignedBefore(request: HasPersonSignedBeforeRequest): Boolean {
+    fun hasPersonSignedBefore(request: HasSignedBeforeRequest): Boolean {
         return memberServiceClient.hasPersonSignedBefore(request)
+    }
+
+    fun hasRedFlag(memberId: String): Boolean {
+        try {
+            val personStatus = memberServiceClient.getPersonStatusByMemberId(memberId)
+            if (personStatus.isWhitelisted) {
+                return false
+            }
+            if (personStatus.flag == Flag.RED) {
+                return true
+            }
+            return false
+        } catch (exception: Exception) {
+            return false
+        }
     }
 }

--- a/src/main/java/com/hedvig/notificationService/customerio/hedvigfacades/MemberServiceImpl.kt
+++ b/src/main/java/com/hedvig/notificationService/customerio/hedvigfacades/MemberServiceImpl.kt
@@ -10,8 +10,14 @@ class MemberServiceImpl(private val memberServiceClient: MemberServiceClient) {
         return Locale.forLanguageTag(memberServiceClient.pickedLocale(memberId).body.pickedLocale.replace('_', '-'))
     }
 
-    fun hasPersonSignedBefore(request: HasSignedBeforeRequest): Boolean {
-        return memberServiceClient.hasPersonSignedBefore(request)
+    fun hasPersonSignedBefore(memberId: String, ssn: String?, email: String): Boolean {
+        return memberServiceClient.hasPersonSignedBefore(
+            HasSignedBeforeRequest(
+                memberId = memberId,
+                ssn = ssn,
+                email = email
+            )
+        )
     }
 
     fun hasRedFlag(memberId: String): Boolean {

--- a/src/main/java/com/hedvig/notificationService/service/event/EventHandler.kt
+++ b/src/main/java/com/hedvig/notificationService/service/event/EventHandler.kt
@@ -8,7 +8,6 @@ import com.hedvig.notificationService.customerio.state.CustomerIOStateRepository
 import com.hedvig.notificationService.customerio.state.CustomerioState
 import com.hedvig.notificationService.service.firebase.FirebaseNotificationService
 import com.hedvig.notificationService.service.request.HandledRequestRepository
-import com.hedvig.notificationService.serviceIntegration.memberService.dto.HasSignedBeforeRequest
 import org.quartz.Scheduler
 import org.quartz.SchedulerException
 import org.slf4j.LoggerFactory
@@ -118,11 +117,9 @@ class EventHandler(
             return
         }
         val hasSignedBefore = memberService.hasPersonSignedBefore(
-            HasSignedBeforeRequest(
-                memberId = event.memberId,
-                ssn = event.ssn,
-                email = event.email
-            )
+            memberId = event.memberId,
+            ssn = event.ssn,
+            email = event.email
         )
         if (hasSignedBefore) {
             logger.info("Will not send QuoteCreatedEvent to customer.io for member=${event.memberId} since the person signed before")

--- a/src/main/java/com/hedvig/notificationService/serviceIntegration/memberService/FakeMemberServiceClient.kt
+++ b/src/main/java/com/hedvig/notificationService/serviceIntegration/memberService/FakeMemberServiceClient.kt
@@ -1,7 +1,9 @@
 package com.hedvig.notificationService.serviceIntegration.memberService
 
+import com.hedvig.notificationService.serviceIntegration.memberService.dto.Flag
 import com.hedvig.notificationService.serviceIntegration.memberService.dto.Member
-import com.hedvig.notificationService.serviceIntegration.memberService.dto.HasPersonSignedBeforeRequest
+import com.hedvig.notificationService.serviceIntegration.memberService.dto.HasSignedBeforeRequest
+import com.hedvig.notificationService.serviceIntegration.memberService.dto.PersonStatusDto
 import org.springframework.http.ResponseEntity
 
 class FakeMemberServiceClient : MemberServiceClient {
@@ -37,5 +39,6 @@ class FakeMemberServiceClient : MemberServiceClient {
         return ResponseEntity.ok(PickedLocale("nb_NO"))
     }
 
-    override fun hasPersonSignedBefore(request: HasPersonSignedBeforeRequest): Boolean = false
+    override fun hasPersonSignedBefore(request: HasSignedBeforeRequest): Boolean = false
+    override fun getPersonStatusByMemberId(memberId: String): PersonStatusDto = PersonStatusDto(Flag.GREEN, false)
 }

--- a/src/main/java/com/hedvig/notificationService/serviceIntegration/memberService/MemberServiceClient.kt
+++ b/src/main/java/com/hedvig/notificationService/serviceIntegration/memberService/MemberServiceClient.kt
@@ -1,7 +1,8 @@
 package com.hedvig.notificationService.serviceIntegration.memberService
 
 import com.hedvig.notificationService.serviceIntegration.memberService.dto.Member
-import com.hedvig.notificationService.serviceIntegration.memberService.dto.HasPersonSignedBeforeRequest
+import com.hedvig.notificationService.serviceIntegration.memberService.dto.HasSignedBeforeRequest
+import com.hedvig.notificationService.serviceIntegration.memberService.dto.PersonStatusDto
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -23,5 +24,8 @@ interface MemberServiceClient {
     fun pickedLocale(@PathVariable("memberId") memberId: String): ResponseEntity<PickedLocale>
 
     @PostMapping("/_/person/has/signed")
-    fun hasPersonSignedBefore(request: HasPersonSignedBeforeRequest): Boolean
+    fun hasPersonSignedBefore(request: HasSignedBeforeRequest): Boolean
+
+    @GetMapping("/_/person/member/{memberId}")
+    fun getPersonStatusByMemberId(@PathVariable memberId: String): PersonStatusDto
 }

--- a/src/main/java/com/hedvig/notificationService/serviceIntegration/memberService/dto/Flag.kt
+++ b/src/main/java/com/hedvig/notificationService/serviceIntegration/memberService/dto/Flag.kt
@@ -1,0 +1,7 @@
+package com.hedvig.notificationService.serviceIntegration.memberService.dto
+
+enum class Flag {
+    GREEN,
+    AMBER,
+    RED
+}

--- a/src/main/java/com/hedvig/notificationService/serviceIntegration/memberService/dto/HasSignedBeforeRequest.kt
+++ b/src/main/java/com/hedvig/notificationService/serviceIntegration/memberService/dto/HasSignedBeforeRequest.kt
@@ -1,6 +1,7 @@
 package com.hedvig.notificationService.serviceIntegration.memberService.dto
 
-data class HasPersonSignedBeforeRequest(
+data class HasSignedBeforeRequest(
+    val memberId: String,
     val ssn: String?,
     val email: String
 )

--- a/src/main/java/com/hedvig/notificationService/serviceIntegration/memberService/dto/PersonStatusDto.kt
+++ b/src/main/java/com/hedvig/notificationService/serviceIntegration/memberService/dto/PersonStatusDto.kt
@@ -1,0 +1,6 @@
+package com.hedvig.notificationService.serviceIntegration.memberService.dto
+
+data class PersonStatusDto(
+    val flag: Flag,
+    val isWhitelisted: Boolean
+)

--- a/src/test/java/com/hedvig/notificationService/customerio/web/OnChargeFailedEventTriggerCustomerioEventTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/web/OnChargeFailedEventTriggerCustomerioEventTest.kt
@@ -84,6 +84,6 @@ class OnChargeFailedEventTriggerCustomerioEventTest {
         )
 
         verify(exactly = 0) { customerioService.sendEvent(any(), any()) }
-        verify(exactly = 0) { handledRequestRepository.storeHandledRequest(requestId) }
+        verify(exactly = 0) { handledRequestRepository.storeHandledRequest(any()) }
     }
 }

--- a/src/test/java/com/hedvig/notificationService/customerio/web/OnQuoteCreatedEventTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/web/OnQuoteCreatedEventTest.kt
@@ -1,14 +1,13 @@
 package com.hedvig.notificationService.customerio.web
 
 import com.hedvig.notificationService.customerio.CustomerioService
-import com.hedvig.notificationService.service.event.EventHandler
 import com.hedvig.notificationService.customerio.builders.EMAIL
 import com.hedvig.notificationService.customerio.builders.MEMBER_ID
 import com.hedvig.notificationService.customerio.builders.SSN
 import com.hedvig.notificationService.customerio.builders.a
 import com.hedvig.notificationService.customerio.hedvigfacades.MemberServiceImpl
+import com.hedvig.notificationService.service.event.EventHandler
 import com.hedvig.notificationService.service.request.HandledRequestRepository
-import com.hedvig.notificationService.serviceIntegration.memberService.dto.HasSignedBeforeRequest
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify

--- a/src/test/java/com/hedvig/notificationService/customerio/web/OnQuoteCreatedEventTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/web/OnQuoteCreatedEventTest.kt
@@ -42,7 +42,7 @@ class OnQuoteCreatedEventTest {
     fun `send event when member is not signed and event is ordinary`() {
         val requestId = "unhandled request"
         val quoteCreatedEvent = a.quoteCreatedEvent.build()
-        every { memberService.hasPersonSignedBefore(HasSignedBeforeRequest(MEMBER_ID, SSN, EMAIL)) } returns false
+        every { memberService.hasPersonSignedBefore(MEMBER_ID, SSN, EMAIL) } returns false
         every { memberService.hasRedFlag(MEMBER_ID) } returns false
         eventHandlerToTest.onQuoteCreatedHandleRequest(quoteCreatedEvent, CALL_TIME, requestId)
         verify { customerioService.sendEvent(MEMBER_ID, quoteCreatedEvent.toMap()) }
@@ -63,58 +63,58 @@ class OnQuoteCreatedEventTest {
     @Test
     fun `does not send event when member signed and event is ordinary`() {
         val quoteCreatedEvent = a.quoteCreatedEvent.build()
-        every { memberService.hasPersonSignedBefore(HasSignedBeforeRequest(MEMBER_ID, SSN, EMAIL)) } returns true
+        every { memberService.hasPersonSignedBefore(MEMBER_ID, SSN, EMAIL) } returns true
         every { memberService.hasRedFlag(MEMBER_ID) } returns false
         eventHandlerToTest.onQuoteCreatedHandleRequest(quoteCreatedEvent, CALL_TIME)
         verify(exactly = 0) {
             customerioService.updateCustomerAttributes(
-                MEMBER_ID,
                 any(),
-                CALL_TIME
+                any(),
+                any()
             )
         }
-        verify(exactly = 0) { customerioService.sendEvent(MEMBER_ID, quoteCreatedEvent.toMap()) }
+        verify(exactly = 0) { customerioService.sendEvent(any(), any()) }
     }
 
     @Test
     fun `does not send event when member has not signed and quote is created from hope`() {
-        every { memberService.hasPersonSignedBefore(HasSignedBeforeRequest(MEMBER_ID, SSN, EMAIL)) } returns false
+        every { memberService.hasPersonSignedBefore(MEMBER_ID, SSN, EMAIL) } returns false
         every { memberService.hasRedFlag(MEMBER_ID) } returns false
         val eventWithQuoteCreatedFromHope = a.quoteCreatedEvent.copy(initiatedFrom = "HOPE").build()
         eventHandlerToTest.onQuoteCreatedHandleRequest(eventWithQuoteCreatedFromHope, CALL_TIME)
-        verify(exactly = 0) { customerioService.updateCustomerAttributes(MEMBER_ID, any(), CALL_TIME) }
-        verify(exactly = 0) { customerioService.sendEvent(MEMBER_ID, any()) }
+        verify(exactly = 0) { customerioService.updateCustomerAttributes(any(), any(), any()) }
+        verify(exactly = 0) { customerioService.sendEvent(any(), any()) }
     }
 
     @Test
     fun `does not send event when member has red flag`() {
-        every { memberService.hasPersonSignedBefore(HasSignedBeforeRequest(MEMBER_ID, SSN, EMAIL)) } returns false
+        every { memberService.hasPersonSignedBefore(MEMBER_ID, SSN, EMAIL) } returns false
         every { memberService.hasRedFlag(MEMBER_ID) } returns true
         val eventWithQuoteCreatedFromHope = a.quoteCreatedEvent.copy(initiatedFrom = "HOPE").build()
         eventHandlerToTest.onQuoteCreatedHandleRequest(eventWithQuoteCreatedFromHope, CALL_TIME)
-        verify(exactly = 0) { customerioService.updateCustomerAttributes(MEMBER_ID, any(), CALL_TIME) }
-        verify(exactly = 0) { customerioService.sendEvent(MEMBER_ID, any()) }
+        verify(exactly = 0) { customerioService.updateCustomerAttributes(any(), any(), any()) }
+        verify(exactly = 0) { customerioService.sendEvent(any(), any()) }
     }
 
     @Test
     fun `does not send event when member has not signed and quote has originating productId`() {
-        every { memberService.hasPersonSignedBefore(HasSignedBeforeRequest(MEMBER_ID, SSN, EMAIL)) } returns false
+        every { memberService.hasPersonSignedBefore(MEMBER_ID, SSN, EMAIL) } returns false
         every { memberService.hasRedFlag(MEMBER_ID) } returns false
         val eventWithQuoteWithOriginatingProductId =
             a.quoteCreatedEvent.copy(originatingProductId = UUID.randomUUID()).build()
         eventHandlerToTest.onQuoteCreatedHandleRequest(eventWithQuoteWithOriginatingProductId, CALL_TIME)
-        verify(exactly = 0) { customerioService.updateCustomerAttributes(MEMBER_ID, any(), CALL_TIME) }
-        verify(exactly = 0) { customerioService.sendEvent(MEMBER_ID, any()) }
+        verify(exactly = 0) { customerioService.updateCustomerAttributes(any(), any(), any()) }
+        verify(exactly = 0) { customerioService.sendEvent(any(), any()) }
     }
 
     @Test
     fun `does not send event when member has not signed and quote has unknown productType`() {
-        every { memberService.hasPersonSignedBefore(HasSignedBeforeRequest(MEMBER_ID, SSN, EMAIL)) } returns false
+        every { memberService.hasPersonSignedBefore(MEMBER_ID, SSN, EMAIL) } returns false
         every { memberService.hasRedFlag(MEMBER_ID) } returns false
         val eventWithQuoteWithOriginatingProductId = a.quoteCreatedEvent.copy(productType = "UNKNOWN").build()
         eventHandlerToTest.onQuoteCreatedHandleRequest(eventWithQuoteWithOriginatingProductId, CALL_TIME)
-        verify(exactly = 0) { customerioService.updateCustomerAttributes(MEMBER_ID, any(), CALL_TIME) }
-        verify(exactly = 0) { customerioService.sendEvent(MEMBER_ID, any()) }
+        verify(exactly = 0) { customerioService.updateCustomerAttributes(any(), any(), any()) }
+        verify(exactly = 0) { customerioService.sendEvent(any(), any()) }
     }
 
     @Test

--- a/src/test/java/com/hedvig/notificationService/service/event/HandleEventRequestsTest.kt
+++ b/src/test/java/com/hedvig/notificationService/service/event/HandleEventRequestsTest.kt
@@ -33,7 +33,7 @@ class HandleEventRequestsTest {
         )
 
         verify(exactly = 0) { eventHandler.onStartDateUpdatedEvent(any(), any()) }
-        verify(exactly = 0) { handledRequestRepository.storeHandledRequest(requestId) }
+        verify(exactly = 0) { handledRequestRepository.storeHandledRequest(any()) }
     }
 
     @Test


### PR DESCRIPTION
Why?
- We don't want to send customer.io events for members that have signed with the same member id
- We don't want to send customer.io events for members that have red flags

What?
- Send member id to "has signed" endpoint 
- Check flag