### PR TITLE
get rid of (unused) TeeFilter to avoid stack trace vomit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mvn clean package -s /usr/share/maven/ref/settings-docker.xml
 
 
 ##### Test stage #####
-FROM scratch AS test
+FROM build AS test
 # Nothing to do - this service only has integration tests
 
 

--- a/src/main/java/com/hedvig/notificationService/configuration/LogBackAccess.java
+++ b/src/main/java/com/hedvig/notificationService/configuration/LogBackAccess.java
@@ -1,7 +1,6 @@
 package com.hedvig.notificationService.configuration;
 
 import ch.qos.logback.access.tomcat.LogbackValve;
-import javax.servlet.Filter;
 import lombok.val;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
@@ -10,11 +9,6 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class LogBackAccess {
-
-  @Bean(name = "TeeFilter")
-  public Filter teeFilter() {
-    return new ch.qos.logback.access.servlet.TeeFilter();
-  }
 
   @Bean
   public ServletWebServerFactory servletContainer() {


### PR DESCRIPTION
# Jira Issue: [] 

## What?
- Remove `TeeFilter`, which gives functionality we don't really use 


## Why?
- `TeeFilter` has [a bug](https://jira.qos.ch/browse/LOGBACK-1527) in it that makes it print stack traces to stderr, which makes us unable to control its format. This causes Datadog to get massive piles of over-reported ERROR statements that drown out the real problems
- `TeeFilter` is used to retain body data for requests and responses so that can be printed. We don't actually use that data anyway, and they [even recommend you don't do that in production](http://logback.qos.ch/recipes/captureHttp.html#disabling)

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [x] Tested locally

