### PR TITLE
MX-194: Make APNs and Android payloads contain the same data

### DIFF
--- a/src/main/java/com/hedvig/notificationService/service/firebase/FirebaseNotificationServiceImpl.kt
+++ b/src/main/java/com/hedvig/notificationService/service/firebase/FirebaseNotificationServiceImpl.kt
@@ -331,12 +331,11 @@ class FirebaseNotificationServiceImpl(
         return Pair(title, body)
     }
 
-    fun translateWithReplacements(
+    private fun translateWithReplacements(
         key: String,
         locale: Locale,
         replacements: Map<String, String> = emptyMap()
     ): String? {
-
         var translation = translations.get(key, locale) ?: return null
         replacements.forEach { (token, text) -> translation = translation.replace("{$token}", text) }
         return translation

--- a/src/main/java/com/hedvig/notificationService/service/firebase/FirebaseNotificationServiceImpl.kt
+++ b/src/main/java/com/hedvig/notificationService/service/firebase/FirebaseNotificationServiceImpl.kt
@@ -45,11 +45,11 @@ class FirebaseNotificationServiceImpl(
         val firebaseToken = firebaseRepository.findById(memberId)
 
         val message = createMessage(
-            memberId,
-            firebaseToken,
-            NEW_MESSAGE,
-            DEFAULT_TITLE,
-            NEW_MESSAGE_BODY,
+            memberId = memberId,
+            firebaseToken = firebaseToken,
+            dataType = NEW_MESSAGE,
+            titleTextKey = DEFAULT_TITLE,
+            bodyTextKey = NEW_MESSAGE_BODY,
             customData = messageText?.let { mapOf(DATA_NEW_MESSAGE_BODY to it) }
         )
 
@@ -65,12 +65,12 @@ class FirebaseNotificationServiceImpl(
         val firebaseToken = firebaseRepository.findById(memberId)
 
         val message = createMessage(
-            memberId,
-            firebaseToken,
-            REFERRAL_SUCCESS,
-            DEFAULT_TITLE,
-            REFERRAL_SUCCESS_BODY,
-            mapOf(
+            memberId = memberId,
+            firebaseToken = firebaseToken,
+            dataType = REFERRAL_SUCCESS,
+            titleTextKey = DEFAULT_TITLE,
+            bodyTextKey = REFERRAL_SUCCESS_BODY,
+            customData = mapOf(
                 DATA_MESSAGE_REFERRED_SUCCESS_NAME to referredName,
                 DATA_MESSAGE_REFERRED_SUCCESS_INCENTIVE_AMOUNT to incentiveAmount,
                 DATA_MESSAGE_REFERRED_SUCCESS_INCENTIVE_CURRENCY to incentiveCurrency
@@ -110,8 +110,13 @@ class FirebaseNotificationServiceImpl(
     override fun sendClaimPaidNotification(memberId: String) {
         val firebaseToken = firebaseRepository.findById(memberId)
 
-        val message = createMessage(memberId, firebaseToken,
-            CLAIM_PAID, CLAIM_PAID_TITLE, CLAIM_PAID_BODY)
+        val message = createMessage(
+            memberId = memberId,
+            firebaseToken = firebaseToken,
+            dataType = CLAIM_PAID,
+            titleTextKey = CLAIM_PAID_TITLE,
+            bodyTextKey = CLAIM_PAID_BODY
+        )
 
         sendNotification(CLAIM_PAID, memberId, message)
     }
@@ -120,11 +125,11 @@ class FirebaseNotificationServiceImpl(
         val firebaseToken = firebaseRepository.findById(memberId)
 
         val message = createMessage(
-            memberId,
-            firebaseToken,
-            INSURANCE_POLICY_UPDATED,
-            INSURANCE_POLICY_UPDATED_TITLE,
-            INSURANCE_POLICY_UPDATED_BODY
+            memberId = memberId,
+            firebaseToken = firebaseToken,
+            dataType = INSURANCE_POLICY_UPDATED,
+            titleTextKey = INSURANCE_POLICY_UPDATED_TITLE,
+            bodyTextKey = INSURANCE_POLICY_UPDATED_BODY
         )
 
         sendNotification(INSURANCE_POLICY_UPDATED, memberId, message)
@@ -133,9 +138,13 @@ class FirebaseNotificationServiceImpl(
     override fun sendInsuranceRenewedNotification(memberId: String) {
         val firebaseToken = firebaseRepository.findById(memberId)
 
-        val message =
-            createMessage(memberId, firebaseToken,
-                INSURANCE_RENEWED, INSURANCE_RENEWED_TITLE, INSURANCE_RENEWED_BODY)
+        val message = createMessage(
+            memberId = memberId,
+            firebaseToken = firebaseToken,
+            dataType = INSURANCE_RENEWED,
+            titleTextKey = INSURANCE_RENEWED_TITLE,
+            bodyTextKey = INSURANCE_RENEWED_BODY
+        )
 
         sendNotification(INSURANCE_RENEWED, memberId, message)
     }
@@ -143,9 +152,13 @@ class FirebaseNotificationServiceImpl(
     override fun sendHedvigReferralsEnabledNotification(memberId: String) {
         val firebaseToken = firebaseRepository.findById(memberId)
 
-        val message =
-            createMessage(memberId, firebaseToken,
-                REFERRALS_ENABLED, REFERRALS_ENABLED_TITLE, REFERRALS_ENABLED_BODY)
+        val message = createMessage(
+            memberId = memberId,
+            firebaseToken = firebaseToken,
+            dataType = REFERRALS_ENABLED,
+            titleTextKey = REFERRALS_ENABLED_TITLE,
+            bodyTextKey = REFERRALS_ENABLED_BODY
+        )
 
         sendNotification(REFERRALS_ENABLED, memberId, message)
     }
@@ -153,8 +166,13 @@ class FirebaseNotificationServiceImpl(
     override fun sendGenericCommunicationNotification(memberId: String, titleTextKey: String, bodyTextKey: String) {
         val firebaseToken = firebaseRepository.findById(memberId)
 
-        val message = createMessage(memberId, firebaseToken,
-            GENERIC_COMMUNICATION, titleTextKey, bodyTextKey)
+        val message = createMessage(
+            memberId = memberId,
+            firebaseToken = firebaseToken,
+            dataType = GENERIC_COMMUNICATION,
+            titleTextKey = titleTextKey,
+            bodyTextKey = bodyTextKey
+        )
 
         sendNotification(GENERIC_COMMUNICATION, memberId, message)
     }

--- a/src/main/java/com/hedvig/notificationService/service/firebase/FirebaseNotificationServiceImpl.kt
+++ b/src/main/java/com/hedvig/notificationService/service/firebase/FirebaseNotificationServiceImpl.kt
@@ -320,12 +320,7 @@ class FirebaseNotificationServiceImpl(
     ): String? {
 
         var translation = translations.get(key, locale) ?: return null
-
-        logger.info("translation: $translation, replacements: $replacements")
-
         replacements.forEach { (token, text) -> translation = translation.replace("{$token}", text) }
-
-        logger.info("replaced translation: $translation")
         return translation
     }
 

--- a/src/test/java/com/hedvig/notificationService/customerio/web/SchedulingOfActivationDateActiveTodayJobTest.kt
+++ b/src/test/java/com/hedvig/notificationService/customerio/web/SchedulingOfActivationDateActiveTodayJobTest.kt
@@ -177,7 +177,7 @@ fun Assert<Trigger>.matches(
         startTime == actual.startTime
     ) return@given
 
-    expected(
+    this.expected(
         "Trigger with name ${show(actual.key.name)} and startTime ${show(actual.startTime)} did not match ${show(
             name
         )} and $startTime"
@@ -198,5 +198,5 @@ fun Assert<JobDetail>.matches(
         }
     ) return@given
 
-    expected("${show(actual)} did not match expected")
+    this.expected("${show(actual)} did not match expected")
 }

--- a/src/test/java/com/hedvig/notificationService/service/FirebaseNotificationServiceImplTest.kt
+++ b/src/test/java/com/hedvig/notificationService/service/FirebaseNotificationServiceImplTest.kt
@@ -116,10 +116,8 @@ internal class FirebaseNotificationServiceImplTest {
     @Test
     fun sendNewMessageNotificationWithMessage() {
         val title = "title"
-        val body = "body"
         val message = "example message"
         every { translations.get("DEFAULT_TITLE", any()) } returns title
-        every { translations.get("NEW_MESSAGE_BODY", any()) } returns body
         classUnderTest.sendNewMessageNotification(MEMBER_ID, message)
 
         deepMatchMessageCommonData(messages[0], mapOf("TYPE" to "NEW_MESSAGE"))
@@ -128,11 +126,11 @@ internal class FirebaseNotificationServiceImplTest {
             mapOf(
                 "TYPE" to "NEW_MESSAGE",
                 "DATA_MESSAGE_TITLE" to title,
-                "DATA_MESSAGE_BODY" to body,
+                "DATA_MESSAGE_BODY" to message,
                 "DATA_NEW_MESSAGE_BODY" to message
             )
         )
-        deepMatchMessageIOSData(messages[0], title, body)
+        deepMatchMessageIOSData(messages[0], title, message)
     }
 
     @Test
@@ -324,24 +322,6 @@ internal class FirebaseNotificationServiceImplTest {
         )
 
         deepMatchMessageIOSData(messages.first(), "New message!", "You get 123")
-    }
-    @Test
-    fun testCustomMessageContent() {
-        val locale = Locale("sv", "SE")
-        every {
-            translations.get(TextKeys.DEFAULT_TITLE, locale)
-        } returns "New message!"
-        every {
-            memberService.profile("mid").body?.acceptLanguage
-        } returns "sv_SE"
-
-        // No replacements supplied -> nothing replaced
-        classUnderTest.sendNewMessageNotification(
-            "mid",
-            "You can't handle the truth!"
-        )
-
-        deepMatchMessageIOSData(messages.first(), "New message!", "You can't handle the truth!")
     }
 
     private fun deepMatchMessageCommonData(message: Message, map: Map<String, String>) {

--- a/src/test/java/com/hedvig/notificationService/service/FirebaseNotificationServiceImplTest.kt
+++ b/src/test/java/com/hedvig/notificationService/service/FirebaseNotificationServiceImplTest.kt
@@ -11,12 +11,12 @@ import com.hedvig.notificationService.entities.FirebaseRepository
 import com.hedvig.notificationService.entities.FirebaseToken
 import com.hedvig.notificationService.service.firebase.FirebaseNotificationServiceImpl
 import com.hedvig.notificationService.service.firebase.RealFirebaseMessenger
+import com.hedvig.notificationService.service.firebase.TextKeys
 import com.hedvig.notificationService.serviceIntegration.memberService.MemberServiceClient
 import com.hedvig.notificationService.serviceIntegration.memberService.dto.Member
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -91,6 +91,10 @@ internal class FirebaseNotificationServiceImplTest {
 
         messages.clear()
         every { firebaseMessaging.send(capture(messages)) } answers { "" }
+
+        every { translations.get(any(), any()) } answers {
+            it.invocation.args.first() as String
+        }
     }
 
     @Test
@@ -166,14 +170,6 @@ internal class FirebaseNotificationServiceImplTest {
                 "DATA_MESSAGE_REFERRED_SUCCESS_INCENTIVE_CURRENCY" to incentiveCurrency
             )
         )
-
-        verify {
-            classUnderTest.translateWithReplacements(
-                "REFERRAL_SUCCESS_BODY",
-                any(),
-                mapOf("REFERRAL_VALUE" to "10")
-            )
-        }
     }
 
     @Test
@@ -308,42 +304,44 @@ internal class FirebaseNotificationServiceImplTest {
 
     @Test
     fun testReplacementsInTranslations() {
-
-        val locale = Locale("se")
-        val textKey = "textKey"
-        val textWithTokens = "text with token {XXX} and {YYY}"
-        every { translations.get(textKey, any()) } returns textWithTokens
+        val locale = Locale("sv", "SE")
+        every {
+            translations.get(TextKeys.DEFAULT_TITLE, locale)
+        } returns "New message!"
+        every {
+            translations.get(TextKeys.REFERRAL_SUCCESS_BODY, locale)
+        } returns "You get {REFERRAL_VALUE}"
+        every {
+            memberService.profile("mid").body?.acceptLanguage
+        } returns "sv_SE"
 
         // No replacements supplied -> nothing replaced
-        var translation = classUnderTest.translateWithReplacements(textKey, locale)
-        assertThat(translation).isEqualTo(textWithTokens)
-
-        // One replacement supplied -> one replaced
-        translation = classUnderTest.translateWithReplacements(textKey, locale, mapOf("XXX" to "Foo"))
-        assertThat(translation).isEqualTo("text with token Foo and {YYY}")
-
-        // Two replacement supplied -> two replaced
-        translation =
-            classUnderTest.translateWithReplacements(textKey, locale, mapOf("XXX" to "Foo", "YYY" to "bar"))
-        assertThat(translation).isEqualTo("text with token Foo and bar")
-
-        // Three replacement supplied -> two replaced
-        translation = classUnderTest.translateWithReplacements(
-            textKey,
-            locale,
-            mapOf("XXX" to "Foo", "YYY" to "bar", "ZZZ" to "Ish")
+        classUnderTest.sendReferredSuccessNotification(
+            "mid",
+            "Test Persson",
+            "123",
+            ""
         )
-        assertThat(translation).isEqualTo("text with token Foo and bar")
 
-        //  Three replacement supplied, but no tokens in text -> nothing replaced
-        val textWithoutTokens = "Nothing here"
-        every { translations.get(textKey, any()) } returns textWithoutTokens
-        translation = classUnderTest.translateWithReplacements(
-            textKey,
-            locale,
-            mapOf("XXX" to "Foo", "YYY" to "bar", "ZZZ" to "Ish")
+        deepMatchMessageIOSData(messages.first(), "New message!", "You get 123")
+    }
+    @Test
+    fun testCustomMessageContent() {
+        val locale = Locale("sv", "SE")
+        every {
+            translations.get(TextKeys.DEFAULT_TITLE, locale)
+        } returns "New message!"
+        every {
+            memberService.profile("mid").body?.acceptLanguage
+        } returns "sv_SE"
+
+        // No replacements supplied -> nothing replaced
+        classUnderTest.sendNewMessageNotification(
+            "mid",
+            "You can't handle the truth!"
         )
-        assertThat(translation).isEqualTo(textWithoutTokens)
+
+        deepMatchMessageIOSData(messages.first(), "New message!", "You can't handle the truth!")
     }
 
     private fun deepMatchMessageCommonData(message: Message, map: Map<String, String>) {
@@ -371,13 +369,13 @@ internal class FirebaseNotificationServiceImplTest {
             ReflectionTestUtils.getField(message, "apnsConfig") as ApnsConfig,
             "payload"
         ) as Map<String, Any>
-        val iOSTitle =
+        val actualTitle =
             ReflectionTestUtils.getField((apnsConfigPayload["aps"] as Map<String, Any>)["alert"], "title") as String
-        val iOSBody =
+        val actualBody =
             ReflectionTestUtils.getField((apnsConfigPayload["aps"] as Map<String, Any>)["alert"], "body") as String
 
-        assertThat(title).isEqualTo(iOSTitle)
-        assertThat(body).isEqualTo(iOSBody)
+        assertThat(actualTitle).isEqualTo(title)
+        assertThat(actualBody).isEqualTo(body)
         customData?.let {
             it.forEach { entry ->
                 assertThat(apnsConfigPayload).contains(Pair(entry.key, entry.value))


### PR DESCRIPTION
# Jira Issue: [MX-194]

## What?
- Make sure the same data is sent to iOS and Android when pushing

## Why?
- They were misaligned, and we want the same data

## Optional checklist
- [x] Codescouted
- [x] Unit tests written
- [ ] Tested locally



[MX-194]: https://hedvig.atlassian.net/browse/MX-194